### PR TITLE
feat: make copyright year dynamic

### DIFF
--- a/src/layouts/components/footer/footer.tsx
+++ b/src/layouts/components/footer/footer.tsx
@@ -3,7 +3,7 @@ import { AppLink } from "@/components/app-link";
 
 export const Footer = () => (
   <footer className="flex items-center justify-center gap-4">
-    <small className="text-sm">Copyright 2024 mrskiro</small>
+    <small className="text-sm">Copyright {new Date().getFullYear()} mrskiro</small>
     <AppLink
       isExternal
       href="https://github.com/mrskiro/mrskiro.dev"


### PR DESCRIPTION
Update footer copyright to always display current year using new Date().getFullYear()

Fixes #84

Generated with [Claude Code](https://claude.ai/code)